### PR TITLE
D9 compatibility

### DIFF
--- a/cohesion_devel.info.yml
+++ b/cohesion_devel.info.yml
@@ -1,7 +1,7 @@
 name: Site Studio developer
 type: module
 description: 'Developer features for Site Studio.'
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^8 || ^9
 package: Site Studio
 
 dependencies:

--- a/cohesion_devel.info.yml
+++ b/cohesion_devel.info.yml
@@ -3,6 +3,5 @@ type: module
 description: 'Developer features for Site Studio.'
 core_version_requirement: ^8 || ^9
 package: Site Studio
-
 dependencies:
   - cohesion

--- a/cohesion_devel.info.yml
+++ b/cohesion_devel.info.yml
@@ -1,7 +1,8 @@
 name: Site Studio developer
 type: module
 description: 'Developer features for Site Studio.'
-core: 8.x
+core_version_requirement: ^8.9 || ^9
 package: Site Studio
+
 dependencies:
   - cohesion

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "acquia/cohesion-dx8-devel",
+    "name": "vbouchet31/cohesion-dx8-devel",
     "description": "Developer features for Site Studio.",
     "license": "GPL-2.0-or-later",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vbouchet31/cohesion-dx8-devel",
+    "name": "acquia/cohesion-dx8-devel",
     "description": "Developer features for Site Studio.",
     "license": "GPL-2.0-or-later",
     "authors": [

--- a/src/Controller/SassVariablesController.php
+++ b/src/Controller/SassVariablesController.php
@@ -20,8 +20,9 @@ class SassVariablesController extends ControllerBase {
 
   protected function colourVars() {
     $colours = [];
-    $module = system_get_info('module', 'cohesion');
+    $extension_list = \Drupal::service('extension.list.module');
 
+    $module = $extension_list->getExtensionInfo('cohesion');
     if (version_compare('8.x-3.11', $module['version']) === -1) {
       // New (>=5.0)
       $colour_entities = $this->entityTypeManager()


### PR DESCRIPTION
- Update the info.yml to mark it compatible with D9.
- [Replace deprecated system_get_info()](https://api.drupal.org/api/drupal/core%21modules%21system%21system.module/function/system_get_info/8.8.x)