### PR TITLE
ACO-3646 | overriding app.js library when cohesion-dev is available

### DIFF
--- a/cohesion_devel.module
+++ b/cohesion_devel.module
@@ -30,3 +30,25 @@ function cohesion_devel_page_attachments(array &$attachments) {
   }
 
 }
+
+/**
+ * Implements hook_library_info_alter().
+ *
+ * @param $libraries
+ * @param $extension
+ * @return void
+ */
+function cohesion_devel_library_info_alter(&$libraries, $extension) {
+  $cohesion_dev_path = 'cohesion-services/dx8-gateway/assets/dx8/scripts/app.js';
+  if (
+    isset($libraries['cohesion-admin-scripts']) &&
+    file_exists(\Drupal::service('extension.path.resolver')->getPath('module', 'cohesion') . '/' . $cohesion_dev_path)) {
+
+    // Get relative path from stream wrapper.
+    $path = \Drupal::service('file_url_generator')->generateString('public://cohesion/scripts/dx8/app.js');
+
+    // Load the app.js directly from the cohesion-services directory.
+    $app_js_library = array_shift($libraries['cohesion-admin-scripts']['js'][$path]);
+    $libraries['cohesion-admin-scripts']['js'][$cohesion_dev_path] = $app_js_library;
+  }
+}

--- a/cohesion_devel.module
+++ b/cohesion_devel.module
@@ -48,7 +48,8 @@ function cohesion_devel_library_info_alter(&$libraries, $extension) {
     $path = \Drupal::service('file_url_generator')->generateString('public://cohesion/scripts/dx8/app.js');
 
     // Load the app.js directly from the cohesion-services directory.
-    $app_js_library = array_shift($libraries['cohesion-admin-scripts']['js'][$path]);
-    $libraries['cohesion-admin-scripts']['js'][$cohesion_dev_path] = $app_js_library;
+    unset($libraries['cohesion-admin-scripts']['js'][$path]);
+    $libraries['cohesion-admin-scripts']['js'][$cohesion_dev_path] = ['minified' => true];
+
   }
 }


### PR DESCRIPTION
Utilising this module to improve local development velocity by overriding app.js library when cohesion-dev is available

**Motivation**
To avoid having to rebuild containers during development to see changes this addition to the cohesion_devel module would result in the following workflow:

* with cohesion devel enabled...
* Make a change to react app source code
* Run `npm install && npm run production`
* run `ddev drush cr`
* See changes immediately reflected