### PR TITLE
Add sitestudio_debug sub-module

### DIFF
--- a/modules/sitestudio_debug/sitestudio_debug.info.yml
+++ b/modules/sitestudio_debug/sitestudio_debug.info.yml
@@ -1,0 +1,7 @@
+name: Site Studio Debug [experimental]
+machine_name: sitestudio_debug
+type: module
+description: 'Debugging module to catch failed requests [experimental].'
+core_version_requirement: ^10 || ^11
+package: Site Studio
+

--- a/modules/sitestudio_debug/sitestudio_debug.install
+++ b/modules/sitestudio_debug/sitestudio_debug.install
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for sitestudio_debug.
+ */
+
+use Drupal\Core\Database\Schema;
+
+/**
+ * Implements hook_schema().
+ */
+function sitestudio_debug_schema() {
+  $schema['sitestudio_debug_events'] = [
+    'description' => 'Stores Site Studio API request exception events.',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'method' => [
+        'type' => 'varchar',
+        'length' => 16,
+        'not null' => TRUE,
+      ],
+      'uri' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'data' => [
+        'type' => 'text',
+        'size' => 'big',
+        'not null' => FALSE,
+      ],
+      'status_code' => [
+        'type' => 'int',
+        'not null' => FALSE,
+      ],
+      'request_id' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => FALSE,
+      ],
+      'exception_message' => [
+        'type' => 'text',
+        'not null' => FALSE,
+      ],
+      'response_data' => [
+        'type' => 'text',
+        'size' => 'big',
+        'not null' => FALSE,
+      ],
+      'request_duration' => [
+        'type' => 'float',
+        'not null' => FALSE,
+      ],
+      'entity_id' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => FALSE,
+        'description' => 'The ID of the entity being processed when the exception occurred.',
+      ],
+      'entity_type' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => FALSE,
+        'description' => 'The type of entity being processed when the exception occurred.',
+      ],
+    ],
+    'primary key' => ['id'],
+    'indexes' => [
+      'timestamp' => ['timestamp'],
+      'request_id' => ['request_id'],
+      'entity_type' => ['entity_type'],
+      'entity_id' => ['entity_id'],
+    ],
+  ];
+  return $schema;
+}
+

--- a/modules/sitestudio_debug/sitestudio_debug.links.menu.yml
+++ b/modules/sitestudio_debug/sitestudio_debug.links.menu.yml
@@ -1,0 +1,7 @@
+sitestudio_debug.report:
+  title: 'Site Studio Debug Events'
+  description: 'View Site Studio debug events and reports'
+  route_name: sitestudio_debug.report
+  parent: system.admin_reports
+  weight: 10
+

--- a/modules/sitestudio_debug/sitestudio_debug.routing.yml
+++ b/modules/sitestudio_debug/sitestudio_debug.routing.yml
@@ -1,0 +1,8 @@
+sitestudio_debug.report:
+  path: '/admin/reports/sitestudio-debug-events'
+  defaults:
+    _controller: '\Drupal\sitestudio_debug\Controller\EventReportController::report'
+    _title: 'Site Studio Debug Events'
+  requirements:
+    _permission: 'access administration pages'
+

--- a/modules/sitestudio_debug/sitestudio_debug.services.yml
+++ b/modules/sitestudio_debug/sitestudio_debug.services.yml
@@ -1,0 +1,10 @@
+services:
+  sitestudio_debug.event_logger:
+    class: Drupal\sitestudio_debug\Service\EventLoggerService
+    arguments: ['@database']
+  sitestudio_debug.request_exception_subscriber:
+    class: Drupal\sitestudio_debug\EventSubscriber\RequestExceptionEventSubscriber
+    arguments: ['@sitestudio_debug.event_logger']
+    tags:
+      - { name: event_subscriber }
+

--- a/modules/sitestudio_debug/src/Controller/EventReportController.php
+++ b/modules/sitestudio_debug/src/Controller/EventReportController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\sitestudio_debug\Controller;
+
+use Drupal\Core\Url;
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\sitestudio_debug\Service\EventLoggerService;
+
+/**
+ *
+ */
+class EventReportController extends ControllerBase {
+  /** @var \Drupal\sitestudio_debug\Service\EventLoggerService */
+  protected $loggerService;
+
+  public function __construct(EventLoggerService $loggerService) {
+    $this->loggerService = $loggerService;
+  }
+
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('sitestudio_debug.event_logger')
+    );
+  }
+
+  public function report() {
+    $header = [
+      'id' => $this->t('ID'),
+      'timestamp' => $this->t('Timestamp'),
+      'method' => $this->t('Method'),
+      'uri' => $this->t('URI'),
+      'status_code' => $this->t('Status Code'),
+      'request_id' => $this->t('Request ID'),
+      'exception_message' => $this->t('Exception Message'),
+      'data' => $this->t('Request Data'),
+      'response_data' => $this->t('Response Data'),
+      'request_duration' => $this->t('Request Duration'),
+      'operations' => $this->t('Operations'),
+    ];
+    $rows = [];
+    foreach ($this->loggerService->getAllEvents() as $event) {
+      $edit_url = '';
+      if (!empty($event->type) && !empty($event->id)) {
+        try {
+          $url = Url::fromRoute("entity.{$event->type}.edit_form", [
+            $event->type => $event->id,
+          ]);
+          $edit_url = \Drupal::l($this->t('Edit'), $url);
+        } catch (\Exception $e) {
+          $edit_url = '';
+        }
+      }
+      $rows[] = [
+        'id' => $event->id,
+        'timestamp' => date('Y-m-d H:i:s', $event->timestamp),
+        'method' => $event->method,
+        'uri' => $event->uri,
+        'status_code' => $event->status_code,
+        'request_id' => $event->request_id,
+        'exception_message' => $event->exception_message,
+        'data' => $event->data,
+        'response_data' => $event->response_data,
+        'request_duration' => isset($event->request_duration) ? number_format($event->request_duration, 3) : '',
+        'operations' => $edit_url,
+      ];
+    }
+    return [
+      '#type' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+      '#empty' => $this->t('No events found.'),
+    ];
+  }
+
+}

--- a/modules/sitestudio_debug/src/EventSubscriber/RequestExceptionEventSubscriber.php
+++ b/modules/sitestudio_debug/src/EventSubscriber/RequestExceptionEventSubscriber.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\sitestudio_debug\EventSubscriber;
+
+use Drupal\cohesion\Event\RequestExceptionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\sitestudio_debug\Service\EventLoggerService;
+
+/**
+ *
+ */
+class RequestExceptionEventSubscriber implements EventSubscriberInterface {
+  /** @var \Drupal\sitestudio_debug\Service\EventLoggerService */
+  protected $loggerService;
+
+  public function __construct(EventLoggerService $loggerService) {
+    $this->loggerService = $loggerService;
+  }
+
+  public static function getSubscribedEvents() {
+    return [
+      'cohesion.request_exception' => 'onRequestException',
+    ];
+  }
+
+  public function onRequestException(RequestExceptionEvent $event) {
+    // Extract entity information from the event data or URI
+    $entityId = $this->extractEntityId($event);
+    $entityType = $this->extractEntityType($event);
+
+    $this->loggerService->logEvent([
+      'timestamp' => time(),
+      'method' => $event->getMethod(),
+      'uri' => $event->getUri(),
+      'data' => json_encode($event->getPayload()),
+      'status_code' => $event->getStatusCode(),
+      'request_id' => $event->getRequestId(),
+      'exception_message' => $event->getExceptionMessage(),
+      'response_data' => json_encode($event->getResponseData()),
+      'request_duration' => $event->getRequestDuration(),
+      'entity_id' => $entityId,
+      'entity_type' => $entityType,
+    ]);
+  }
+
+  /**
+   * Extract entity ID from the event data or URI.
+   */
+  protected function extractEntityId(RequestExceptionEvent $event) {
+    // Check if entity ID is available in the event data
+    if (method_exists($event, 'getEntityId')) {
+      return $event->getEntityId();
+    }
+
+    // Try to extract from URI patterns
+    $uri = $event->getUri();
+    if (preg_match('/\/entity\/(\w+)\/(\d+)/', $uri, $matches)) {
+      return $matches[2];
+    }
+
+    // Try to extract from request data
+    $data = $event->getData();
+    if (is_array($data)) {
+      if (isset($data['entity_id'])) {
+        return $data['entity_id'];
+      }
+      if (isset($data['id'])) {
+        return $data['id'];
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Extract entity type from the event data or URI.
+   */
+  protected function extractEntityType(RequestExceptionEvent $event) {
+    // Check if entity type is available in the event data
+    if (method_exists($event, 'getEntityType')) {
+      return $event->getEntityType();
+    }
+
+    // Try to extract from URI patterns
+    $uri = $event->getUri();
+    if (preg_match('/\/entity\/(\w+)\/\d+/', $uri, $matches)) {
+      return $matches[1];
+    }
+
+    // Try to extract from request data
+    $data = $event->getData();
+    if (is_array($data)) {
+      if (isset($data['entity_type'])) {
+        return $data['entity_type'];
+      }
+      if (isset($data['type'])) {
+        return $data['type'];
+      }
+    }
+
+    // Try to infer from URI patterns common in Site Studio
+    if (strpos($uri, '/cohesion') !== FALSE) {
+      if (strpos($uri, '/component') !== FALSE) {
+        return 'cohesion_component';
+      }
+      if (strpos($uri, '/layout') !== FALSE) {
+        return 'cohesion_layout';
+      }
+      if (strpos($uri, '/style') !== FALSE) {
+        return 'cohesion_style';
+      }
+      if (strpos($uri, '/template') !== FALSE) {
+        return 'cohesion_template';
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/modules/sitestudio_debug/src/Service/EventLoggerService.php
+++ b/modules/sitestudio_debug/src/Service/EventLoggerService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\sitestudio_debug\Service;
+
+use Drupal\Core\Database\Connection;
+
+/**
+ *
+ */
+class EventLoggerService {
+  /** @var \Drupal\Core\Database\Connection */
+  protected $database;
+
+  public function __construct(Connection $database) {
+    $this->database = $database;
+  }
+
+  /**
+   * Logs an event to the sitestudio_debug_events table.
+   *
+   * @param array $event_data
+   *   The event data to log.
+   */
+  public function logEvent(array $event_data) {
+    $this->database->insert('sitestudio_debug_events')
+      ->fields($event_data)
+      ->execute();
+  }
+
+  /**
+   * Fetches all logged events.
+   *
+   * @return array
+   */
+  public function getAllEvents() {
+    return $this->database->select('sitestudio_debug_events', 'e')
+      ->fields('e')
+      ->orderBy('timestamp', 'DESC')
+      ->execute()
+      ->fetchAll();
+  }
+
+}


### PR DESCRIPTION
**Motivation**
Adding a debug module to capture payloads for failed requests.

**Proposed changes**
We're adding an event that gets dispatched in 8.2 - this module catches the payload and relevant data to simplify and speed-up the debugging process.

**Alternatives considered**
Find a way to capture the payloads in another way??

**Testing steps**
Add a broken API url and see payloads fail and get captured.
